### PR TITLE
Adición de nuevas entities y repositories no existentes anteriormente para la persistencia de datos (Juego, Sala y tablas intermedias).

### DIFF
--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/JuegoEntities.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/JuegoEntities.java
@@ -19,14 +19,22 @@ public class JuegoEntities {
     private int numeroJugadores;
 
     @Column(nullable = false)
-    private boolean necesitaPantalla;
+    private String nombre;
+
+    @Column
+    private String descripcion;
+
+    @Column
+    private String ruta;
 
     public JuegoEntities() {
     }
 
-    public JuegoEntities(int numeroJugadores, boolean necesitaPantalla) {
+    public JuegoEntities(int numeroJugadores, String nombre, String descripcion, String ruta) {
         this.numeroJugadores = numeroJugadores;
-        this.necesitaPantalla = necesitaPantalla;
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.ruta = ruta;
     }
 
     public Long getId() {
@@ -41,12 +49,28 @@ public class JuegoEntities {
         this.numeroJugadores = numeroJugadores;
     }
 
-    public boolean isNecesitaPantalla() {
-        return necesitaPantalla;
+    public String getNombre() {
+        return nombre;
     }
 
-    public void setNecesitaPantalla(boolean necesitaPantalla) {
-        this.necesitaPantalla = necesitaPantalla;
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public String getRuta() {
+        return ruta;
+    }
+
+    public void setRuta(String ruta) {
+        this.ruta = ruta;
     }
 
 }

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/JuegoEntities.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/JuegoEntities.java
@@ -1,0 +1,52 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "juegos_entities")
+public class JuegoEntities {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int numeroJugadores;
+
+    @Column(nullable = false)
+    private boolean necesitaPantalla;
+
+    public JuegoEntities() {
+    }
+
+    public JuegoEntities(int numeroJugadores, boolean necesitaPantalla) {
+        this.numeroJugadores = numeroJugadores;
+        this.necesitaPantalla = necesitaPantalla;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getNumeroJugadores() {
+        return numeroJugadores;
+    }
+
+    public void setNumeroJugadores(int numeroJugadores) {
+        this.numeroJugadores = numeroJugadores;
+    }
+
+    public boolean isNecesitaPantalla() {
+        return necesitaPantalla;
+    }
+
+    public void setNecesitaPantalla(boolean necesitaPantalla) {
+        this.necesitaPantalla = necesitaPantalla;
+    }
+
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaEntities.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaEntities.java
@@ -1,0 +1,64 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "salas_entities")
+public class SalaEntities {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_usuario_id", nullable = false)
+    private Usuario host;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "sala_entities_jugadores",
+            joinColumns = @JoinColumn(name = "sala_id"),
+                inverseJoinColumns = @JoinColumn(name = "usuario_id"))
+            private List<Usuario> jugadores = new ArrayList<>();
+
+    public SalaEntities() {
+    }
+
+    public SalaEntities(Usuario host) {
+        this.host = host;
+        this.jugadores.add(host);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getHost() {
+        return host;
+    }
+
+    public void setHost(Usuario host) {
+        this.host = host;
+    }
+
+    public List<Usuario> getJugadores() {
+        return Collections.unmodifiableList(jugadores);
+    }
+
+    public void setJugadores(List<Usuario> jugadores) {
+        this.jugadores = new ArrayList<>(jugadores);
+    }
+
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoOrden.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoOrden.java
@@ -1,0 +1,94 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "sala_juego", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "sala_id", "orden" })
+})
+public class SalaJuegoOrden {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sala_id", nullable = false)
+    private SalaRegistro sala;
+
+    @Column(nullable = false, length = 120)
+    private String juego;
+
+    @Column(nullable = false)
+    private int orden;
+
+    @Column
+    private LocalDateTime iniciadoEn;
+
+    @Column
+    private LocalDateTime finalizadoEn;
+
+    public SalaJuegoOrden() {
+    }
+
+    public SalaJuegoOrden(SalaRegistro sala, String juego, int orden) {
+        this.sala = sala;
+        this.juego = juego;
+        this.orden = orden;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public SalaRegistro getSala() {
+        return sala;
+    }
+
+    public void setSala(SalaRegistro sala) {
+        this.sala = sala;
+    }
+
+    public String getJuego() {
+        return juego;
+    }
+
+    public void setJuego(String juego) {
+        this.juego = juego;
+    }
+
+    public int getOrden() {
+        return orden;
+    }
+
+    public void setOrden(int orden) {
+        this.orden = orden;
+    }
+
+    public LocalDateTime getIniciadoEn() {
+        return iniciadoEn;
+    }
+
+    public void setIniciadoEn(LocalDateTime iniciadoEn) {
+        this.iniciadoEn = iniciadoEn;
+    }
+
+    public LocalDateTime getFinalizadoEn() {
+        return finalizadoEn;
+    }
+
+    public void setFinalizadoEn(LocalDateTime finalizadoEn) {
+        this.finalizadoEn = finalizadoEn;
+    }
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoOrden.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoOrden.java
@@ -27,8 +27,9 @@ public class SalaJuegoOrden {
     @JoinColumn(name = "sala_id", nullable = false)
     private SalaRegistro sala;
 
-    @Column(nullable = false, length = 120)
-    private String juego;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "juego", nullable = false)
+    private JuegoEntities juego;
 
     @Column(nullable = false)
     private int orden;
@@ -42,7 +43,7 @@ public class SalaJuegoOrden {
     public SalaJuegoOrden() {
     }
 
-    public SalaJuegoOrden(SalaRegistro sala, String juego, int orden) {
+    public SalaJuegoOrden(SalaRegistro sala, JuegoEntities juego, int orden) {
         this.sala = sala;
         this.juego = juego;
         this.orden = orden;
@@ -60,11 +61,11 @@ public class SalaJuegoOrden {
         this.sala = sala;
     }
 
-    public String getJuego() {
+    public JuegoEntities getJuego() {
         return juego;
     }
 
-    public void setJuego(String juego) {
+    public void setJuego(JuegoEntities juego) {
         this.juego = juego;
     }
 

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoResultado.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJuegoResultado.java
@@ -1,0 +1,94 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "sala_juego_resultado", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "sala_juego_id", "usuario_id" })
+})
+public class SalaJuegoResultado {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sala_juego_id", nullable = false)
+    private SalaJuegoOrden salaJuego;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private int puntuacion;
+
+    @Column
+    private Integer posicion;
+
+    @Column(nullable = false)
+    private boolean victoria;
+
+    public SalaJuegoResultado() {
+    }
+
+    public SalaJuegoResultado(SalaJuegoOrden salaJuego, Usuario usuario, int puntuacion, boolean victoria) {
+        this.salaJuego = salaJuego;
+        this.usuario = usuario;
+        this.puntuacion = puntuacion;
+        this.victoria = victoria;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public SalaJuegoOrden getSalaJuego() {
+        return salaJuego;
+    }
+
+    public void setSalaJuego(SalaJuegoOrden salaJuego) {
+        this.salaJuego = salaJuego;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public int getPuntuacion() {
+        return puntuacion;
+    }
+
+    public void setPuntuacion(int puntuacion) {
+        this.puntuacion = puntuacion;
+    }
+
+    public Integer getPosicion() {
+        return posicion;
+    }
+
+    public void setPosicion(Integer posicion) {
+        this.posicion = posicion;
+    }
+
+    public boolean isVictoria() {
+        return victoria;
+    }
+
+    public void setVictoria(boolean victoria) {
+        this.victoria = victoria;
+    }
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJugadorRegistro.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaJugadorRegistro.java
@@ -1,0 +1,131 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "sala_jugador", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "sala_id", "usuario_id" })
+})
+public class SalaJugadorRegistro {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sala_id", nullable = false)
+    private SalaRegistro sala;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @Column(nullable = false)
+    private int victorias;
+
+    @Column(nullable = false)
+    private int derrotas;
+
+    @Column(nullable = false)
+    private int partidasJugadas;
+
+    @Column(nullable = false)
+    private int puntuacionTotal;
+
+    @Column
+    private LocalDateTime unidoEn;
+
+    @Column
+    private LocalDateTime salidoEn;
+
+    public SalaJugadorRegistro() {
+    }
+
+    public SalaJugadorRegistro(SalaRegistro sala, Usuario usuario) {
+        this.sala = sala;
+        this.usuario = usuario;
+        this.victorias = 0;
+        this.derrotas = 0;
+        this.partidasJugadas = 0;
+        this.puntuacionTotal = 0;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public SalaRegistro getSala() {
+        return sala;
+    }
+
+    public void setSala(SalaRegistro sala) {
+        this.sala = sala;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public int getVictorias() {
+        return victorias;
+    }
+
+    public void setVictorias(int victorias) {
+        this.victorias = victorias;
+    }
+
+    public int getDerrotas() {
+        return derrotas;
+    }
+
+    public void setDerrotas(int derrotas) {
+        this.derrotas = derrotas;
+    }
+
+    public int getPartidasJugadas() {
+        return partidasJugadas;
+    }
+
+    public void setPartidasJugadas(int partidasJugadas) {
+        this.partidasJugadas = partidasJugadas;
+    }
+
+    public int getPuntuacionTotal() {
+        return puntuacionTotal;
+    }
+
+    public void setPuntuacionTotal(int puntuacionTotal) {
+        this.puntuacionTotal = puntuacionTotal;
+    }
+
+    public LocalDateTime getUnidoEn() {
+        return unidoEn;
+    }
+
+    public void setUnidoEn(LocalDateTime unidoEn) {
+        this.unidoEn = unidoEn;
+    }
+
+    public LocalDateTime getSalidoEn() {
+        return salidoEn;
+    }
+
+    public void setSalidoEn(LocalDateTime salidoEn) {
+        this.salidoEn = salidoEn;
+    }
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaRegistro.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaRegistro.java
@@ -32,11 +32,15 @@ public class SalaRegistro {
     @Column
     private LocalDateTime cerradaEn;
 
+    @Column(nullable = false)
+    private int maxJugadores;
+
     public SalaRegistro() {
     }
 
-    public SalaRegistro(Usuario hostUsuario) {
+    public SalaRegistro(Usuario hostUsuario, int maxJugadores) {
         this.hostUsuario = hostUsuario;
+        this.maxJugadores = maxJugadores;
     }
 
     @PrePersist
@@ -73,5 +77,13 @@ public class SalaRegistro {
 
     public void setCerradaEn(LocalDateTime cerradaEn) {
         this.cerradaEn = cerradaEn;
+    }
+
+    public int getMaxJugadores() {
+        return maxJugadores;
+    }
+
+    public void setMaxJugadores(int maxJugadores) {
+        this.maxJugadores = maxJugadores;
     }
 }

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaRegistro.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/modelos/SalaRegistro.java
@@ -1,0 +1,77 @@
+package com.juegos1000tres.juegos1000tres_backend.modelos;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "sala")
+public class SalaRegistro {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_usuario_id", nullable = false)
+    private Usuario hostUsuario;
+
+
+    @Column(nullable = false)
+    private LocalDateTime creadaEn;
+
+    @Column
+    private LocalDateTime cerradaEn;
+
+    public SalaRegistro() {
+    }
+
+    public SalaRegistro(Usuario hostUsuario) {
+        this.hostUsuario = hostUsuario;
+    }
+
+    @PrePersist
+    @SuppressWarnings("unused")
+    private void prepararCreacion() {
+        if (creadaEn == null) {
+            creadaEn = LocalDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Usuario getHostUsuario() {
+        return hostUsuario;
+    }
+
+    public void setHostUsuario(Usuario hostUsuario) {
+        this.hostUsuario = hostUsuario;
+    }
+
+    public LocalDateTime getCreadaEn() {
+        return creadaEn;
+    }
+
+    public void setCreadaEn(LocalDateTime creadaEn) {
+        this.creadaEn = creadaEn;
+    }
+
+    public LocalDateTime getCerradaEn() {
+        return cerradaEn;
+    }
+
+    public void setCerradaEn(LocalDateTime cerradaEn) {
+        this.cerradaEn = cerradaEn;
+    }
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/JuegoEntitiesRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/JuegoEntitiesRepository.java
@@ -1,0 +1,12 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.JuegoEntities;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "juegos-entities", collectionResourceRel = "juegos-entities")
+public interface JuegoEntitiesRepository extends JpaRepository<JuegoEntities, Long> {
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaEntitiesRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaEntitiesRepository.java
@@ -1,0 +1,12 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaEntities;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "salas-entities", collectionResourceRel = "salas-entities")
+public interface SalaEntitiesRepository extends JpaRepository<SalaEntities, Long> {
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJuegoOrdenRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJuegoOrdenRepository.java
@@ -1,0 +1,18 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaJuegoOrden;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "salas-juegos", collectionResourceRel = "salas-juegos")
+public interface SalaJuegoOrdenRepository extends JpaRepository<SalaJuegoOrden, Long> {
+
+    @RestResource(path = "por-sala", rel = "por-sala")
+    List<SalaJuegoOrden> findBySalaIdOrderByOrdenAsc(Long salaId);
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJuegoResultadoRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJuegoResultadoRepository.java
@@ -1,0 +1,21 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaJuegoResultado;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "salas-juegos-resultados", collectionResourceRel = "salas-juegos-resultados")
+public interface SalaJuegoResultadoRepository extends JpaRepository<SalaJuegoResultado, Long> {
+
+    @RestResource(path = "por-sala-juego", rel = "por-sala-juego")
+    List<SalaJuegoResultado> findBySalaJuegoId(Long salaJuegoId);
+
+    @RestResource(path = "por-usuario", rel = "por-usuario")
+    List<SalaJuegoResultado> findByUsuarioId(Long usuarioId);
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJugadorRegistroRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaJugadorRegistroRepository.java
@@ -1,0 +1,21 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaJugadorRegistro;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "salas-jugadores", collectionResourceRel = "salas-jugadores")
+public interface SalaJugadorRegistroRepository extends JpaRepository<SalaJugadorRegistro, Long> {
+
+    @RestResource(path = "por-sala", rel = "por-sala")
+    List<SalaJugadorRegistro> findBySalaId(Long salaId);
+
+    @RestResource(path = "por-usuario", rel = "por-usuario")
+    List<SalaJugadorRegistro> findByUsuarioId(Long usuarioId);
+}

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaRegistroRepository.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/repositorios/SalaRegistroRepository.java
@@ -1,0 +1,19 @@
+package com.juegos1000tres.juegos1000tres_backend.repositorios;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaRegistro;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RepositoryRestResource(path = "salas", collectionResourceRel = "salas")
+public interface SalaRegistroRepository extends JpaRepository<SalaRegistro, Long> {
+
+    @RestResource(path = "por-host", rel = "por-host")
+    List<SalaRegistro> findByHostUsuarioId(Long hostUsuarioId);
+
+}


### PR DESCRIPTION
## Resumen
En este PR se añaden varias entities y repositories nuevos con el objetivo de poder llevar un registro de las partidas con los datos que puedan ser importantes. En específico se añaden entities para Juegos y Sala (Ya existian Juego y Sala, pero eran modelos para hacer conexiones con el front) con sus respectivos repositories. También se añaden tablas intermedias para la gestión de datos relacionados con dos entidades.

## Issue relacionado

Closes #23 

## Tipo de cambio
- [ ] Chore
- [ ] Bugfix
- [x] Nueva funcionalidad
- [ ] Refactor
- [ ] Documentacion
- [x] Otro

## Decisiones técnicas (opcional)

## Como probar
1. Primero es necesario levantar tanto el backend como la base de datos con el docker compose existente en la raíz del proyecto. 
2.  Para probar la persistencia de datos es necesario hacer uso de GET y POST para hacer llamadas a la API REST y así añadir los datos nuevos y probar que se pueden obtener. 

## Checklist
- [x] He probado mis cambios localmente
- [x] No rompo funcionalidad existente
- [x] Incluyo pruebas o justifico por que no aplica

## Evidencia (opcional)
Para probar que de verdad es funcional es recomendable que cada uno lo pruebe por su cuenta en vez de depender de capturas.
