### PR TITLE
Docker frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,16 @@ services:
       postgres:
         condition: service_healthy
 
+  frontend:
+    build:
+      context: ./juegos1000tres-frontend
+      dockerfile: Dockerfile
+    container_name: juegos1000tres-frontend-app
+    ports:
+      - "4200:4200"
+    depends_on:
+      - backend
+
 volumes:
   postgres_data:
   maven_cache:

--- a/juegos1000tres-frontend/.dockerignore
+++ b/juegos1000tres-frontend/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+npm-debug.log
+.DS_Store
+dist
+coverage
+.git
+.gitignore
+node_modules
+npm-debug.log
+.DS_Store
+dist
+coverage
+.git
+.gitignore

--- a/juegos1000tres-frontend/Dockerfile
+++ b/juegos1000tres-frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/juegos1000tres-frontend/browser /usr/share/nginx/html
+
+EXPOSE 4200
+CMD ["nginx", "-g", "daemon off;"]

--- a/juegos1000tres-frontend/angular.json
+++ b/juegos1000tres-frontend/angular.json
@@ -39,8 +39,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "12kB",
+                  "maximumError": "24kB"
                 }
               ],
               "outputHashing": "all"

--- a/juegos1000tres-frontend/nginx.conf
+++ b/juegos1000tres-frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 4200;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Resumen
En este PR se añade tanto el Dockerfile para el frontend y se añade al docker compose

## Issue relacionado

Closes #47 

## Tipo de cambio
- [x] Chore
- [ ] Bugfix
- [ ] Nueva funcionalidad
- [ ] Refactor
- [ ] Documentacion
- [ ] Otro

## Decisiones técnicas (opcional)
- Se ha decidido añadir un Dockerfile para hacer build del frontend y se ha añadido al docker compose en la raíz del proyecto. De esta forma la aplicación se levanta con un solo comando.



## Como probar
1. Acceder a la raíz del repositorio y usar el comando "docker compose up --build"
2. Acceder a localhost:4200. Es un servidor local, pero igualmente sigue teniendo localhost en la URL porque para cambiarlo hay que añadirlo al archivos hosts de windows.

## Checklist
- [x] He probado mis cambios localmente
- [x] No rompo funcionalidad existente
- [x] Incluyo pruebas o justifico por que no aplica

## Evidencia (opcional)
La evidencia se consigue probando la aplicación siguiendo los pasos indicados más arriba.
