### PR TITLE
Estadisticas a partir de historial

### DIFF
--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/sala/HistorialController.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/sala/HistorialController.java
@@ -93,11 +93,10 @@ public class HistorialController {
     }
 
     private HistorialJuegoRespuesta mapearJuego(SalaJuegoOrden juego, Long usuarioId, String nombreUsuario, boolean esHost) {
-        List<SalaJuegoResultado> resultados = juego.getJugadores().stream()
-                .filter(resultado -> esHost || perteneceAlUsuario(resultado, usuarioId, nombreUsuario))
-                .toList();
+        List<SalaJuegoResultado> resultados = juego.getJugadores();
 
-        boolean participo = !resultados.isEmpty();
+        boolean participo = esHost || resultados.stream()
+                .anyMatch(resultado -> perteneceAlUsuario(resultado, usuarioId, nombreUsuario));
 
         if (!participo) {
             return null;

--- a/juegos1000tres-backend/src/test/java/com/juegos1000tres/juegos1000tres_backend/sala/HistorialControllerTest.java
+++ b/juegos1000tres-backend/src/test/java/com/juegos1000tres/juegos1000tres_backend/sala/HistorialControllerTest.java
@@ -1,0 +1,138 @@
+package com.juegos1000tres.juegos1000tres_backend.sala;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import com.juegos1000tres.juegos1000tres_backend.auth.AuthRole;
+import com.juegos1000tres.juegos1000tres_backend.auth.AuthUser;
+import com.juegos1000tres.juegos1000tres_backend.auth.JwtService;
+import com.juegos1000tres.juegos1000tres_backend.modelos.JuegoEntities;
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaEntities;
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaJuegoOrden;
+import com.juegos1000tres.juegos1000tres_backend.modelos.SalaJuegoResultado;
+import com.juegos1000tres.juegos1000tres_backend.modelos.Usuario;
+import com.juegos1000tres.juegos1000tres_backend.repositorios.SalaEntitiesRepository;
+import com.juegos1000tres.juegos1000tres_backend.repositorios.UsuarioRepository;
+
+class HistorialControllerTest {
+
+    @Test
+    void obtenerHistorialIncluyeTodosLosJugadoresCuandoElUsuarioParticipo() {
+        SalaEntities sala = new SalaEntities("483143", "b", LocalDate.of(2026, 5, 27));
+        sala.setHostUsuarioId(1L);
+
+        JuegoEntities juegoEntidad = new JuegoEntities(2, "reflejos-p2p", "descripcion", "reflejos-p2p");
+        SalaJuegoOrden juego = new SalaJuegoOrden(sala, juegoEntidad, 1);
+
+        SalaJuegoResultado host = new SalaJuegoResultado(juego, "b", 1L, 1, true);
+        host.setPosicion(1);
+        SalaJuegoResultado invitado = new SalaJuegoResultado(juego, "a", 7L, 0, false);
+        invitado.setPosicion(2);
+
+        juego.registrarJugador(host);
+        juego.registrarJugador(invitado);
+        sala.registrarJuego(juego);
+
+        SalaEntitiesRepository salaRepository = proxy(SalaEntitiesRepository.class, (proxy, method, args) -> {
+            if ("findAll".equals(method.getName()) && args != null && args.length == 1 && args[0] instanceof Sort) {
+                return List.of(sala);
+            }
+
+            return valorPorDefecto(method.getReturnType());
+        });
+
+        Usuario usuario = new Usuario("a", "a@example.com", "secret");
+        asignarId(usuario, 7L);
+
+        UsuarioRepository usuarioRepository = proxy(UsuarioRepository.class, (proxy, method, args) -> {
+            if ("findByEmailIgnoreCase".equals(method.getName())) {
+                return Optional.of(usuario);
+            }
+
+            return valorPorDefecto(method.getReturnType());
+        });
+
+        JwtService jwtService = new JwtService("01234567890123456789012345678901", 60) {
+            @Override
+            public AuthUser getCurrentUser() {
+                return new AuthUser("a", "a@example.com", AuthRole.USER);
+            }
+        };
+
+        HistorialController controller = new HistorialController(salaRepository, usuarioRepository, jwtService);
+
+        List<HistorialController.HistorialSalaRespuesta> historial = controller.obtenerHistorial();
+
+        assertEquals(1, historial.size());
+        HistorialController.HistorialSalaRespuesta salaRespuesta = historial.get(0);
+        assertEquals("483143", salaRespuesta.uuid());
+        assertEquals(1, salaRespuesta.juegosJugados().size());
+
+        HistorialController.HistorialJuegoRespuesta juegoRespuesta = salaRespuesta.juegosJugados().get(0);
+        assertEquals(2, juegoRespuesta.jugadores().size());
+        assertEquals(List.of("b"), juegoRespuesta.ganadores());
+        assertFalse(juegoRespuesta.jugadores().stream().allMatch(jugador -> "a".equals(jugador.nombreJugador())));
+        assertTrue(juegoRespuesta.jugadores().stream().anyMatch(jugador -> "b".equals(jugador.nombreJugador())));
+        assertTrue(juegoRespuesta.jugadores().stream().anyMatch(jugador -> "a".equals(jugador.nombreJugador())));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type }, handler);
+    }
+
+    private static Object valorPorDefecto(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        if (returnType == double.class) {
+            return 0d;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+
+        return null;
+    }
+
+    private static void asignarId(Usuario usuario, Long id) {
+        try {
+            Field field = Usuario.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(usuario, id);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/juegos1000tres-frontend/src/app/app.routes.ts
+++ b/juegos1000tres-frontend/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { Auth } from './features/auth/auth';
 import { Home } from './features/home/home';
 import { Lobby } from './features/lobby/lobby';
 import { Historial } from './features/historial/historial';
+import { Estadisticas } from './features/estadisticas/estadisticas';
 import { Login } from './features/auth/components/login/login';
 import { Register } from './features/auth/components/register/register';
 import { authGuard } from './core/guards/auth.guard';
@@ -25,6 +26,7 @@ export const routes: Routes = [
 	},
 	{ path: 'sala', component: Lobby, canActivate: [authGuard] },
 	{ path: 'sala/:uuid', component: Lobby, canActivate: [authGuard] },
+	{ path: 'estadisticas', component: Estadisticas, canActivate: [registeredGuard] },
 	{ path: 'historial', component: Historial, canActivate: [registeredGuard] },
 	{ path: 'reflejos-p2p/:uuid', component: ReflejosP2PComponent, canActivate: [authGuard] },
 	{ path: 'pantalla-reflejos/:uuid', component: PantallaReflejosComponent, canActivate: [authGuard] },

--- a/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.css
+++ b/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.css
@@ -1,0 +1,292 @@
+:host {
+	--bg-deep: #050510;
+	--bg-panel: #0d0d26;
+	--bg-card: #11112a;
+	--border-dim: rgba(255, 255, 255, 0.08);
+	--border-glow: rgba(255, 255, 255, 0.18);
+	--text-primary: #e8e8ff;
+	--text-muted: #7878aa;
+	--accent: #a855f7;
+	--accent-lit: #c084fc;
+	--green: #00ff88;
+	--transition: 0.25s cubic-bezier(.4, 0, .2, 1);
+	--shadow-panel: 0 24px 70px rgba(0, 0, 0, 0.42);
+	--shadow-glow: 0 0 36px rgba(168, 85, 247, 0.16);
+	--radius-card: 18px;
+	--font-pixel: 'Press Start 2P', monospace;
+	--font-ui: 'Outfit', sans-serif;
+
+	display: block;
+	min-height: 100vh;
+	background: var(--bg-deep);
+	color: var(--text-primary);
+	font-family: var(--font-ui);
+	position: relative;
+	overflow: hidden;
+}
+
+:host::before {
+	content: '';
+	position: fixed;
+	inset: 0;
+	background:
+		radial-gradient(ellipse 80% 60% at 20% 0%, rgba(124, 58, 237, 0.25) 0%, transparent 60%),
+		radial-gradient(ellipse 60% 50% at 80% 100%, rgba(0, 255, 136, 0.12) 0%, transparent 60%),
+		linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+	background-size: auto, auto, 42px 42px, 42px 42px;
+	pointer-events: none;
+	z-index: 0;
+}
+
+:host::after {
+	content: '';
+	position: fixed;
+	inset: 0;
+	background: radial-gradient(circle at 50% 50%, transparent 0%, rgba(5, 5, 16, 0.26) 68%, rgba(0, 0, 0, 0.44) 100%);
+	pointer-events: none;
+	z-index: 0;
+}
+
+.estadisticas-page {
+	position: relative;
+	z-index: 1;
+	min-height: 100vh;
+	padding: 2rem;
+}
+
+.estadisticas-hero {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 1.5rem;
+	flex-wrap: wrap;
+	margin: 0 auto 2rem;
+	max-width: 1180px;
+	padding: 1.5rem 1.6rem;
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 24px;
+	background: linear-gradient(180deg, rgba(17, 17, 42, 0.72), rgba(13, 13, 38, 0.48));
+	box-shadow: var(--shadow-panel), var(--shadow-glow), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	backdrop-filter: blur(16px);
+}
+
+.estadisticas-copy {
+	max-width: 700px;
+}
+
+.eyebrow {
+	margin: 0 0 0.5rem;
+	color: var(--green);
+	font-size: 0.72rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+}
+
+.estadisticas-copy h1 {
+	margin: 0;
+	font-family: var(--font-pixel);
+	font-size: 1.35rem;
+	letter-spacing: 0.08em;
+	line-height: 1.5;
+}
+
+.estadisticas-copy p {
+	margin: 0.8rem 0 0;
+	color: var(--text-muted);
+	max-width: 62ch;
+}
+
+.estadisticas-actions {
+	display: flex;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+}
+
+.estadisticas-state {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 1rem 1.2rem;
+	border-radius: 16px;
+	background: rgba(17, 17, 42, 0.65);
+	border: 1px solid var(--border-dim);
+	color: var(--text-muted);
+}
+
+.estadisticas-state.error {
+	color: #ff9a9a;
+	border-color: rgba(255, 92, 92, 0.3);
+}
+
+.estadisticas-state.empty {
+	color: var(--text-muted);
+}
+
+.estadisticas-panel {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 1.4rem;
+	border-radius: var(--radius-card);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	background: linear-gradient(180deg, rgba(17, 17, 42, 0.9), rgba(13, 13, 38, 0.82));
+	box-shadow: var(--shadow-panel);
+}
+
+.estadisticas-panel-head {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	flex-wrap: wrap;
+	padding-bottom: 1rem;
+	margin-bottom: 1rem;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.panel-label,
+.columna-meta span,
+.eje-y span {
+	color: var(--text-muted);
+}
+
+.estadisticas-panel-head strong {
+	display: block;
+	margin-top: 0.25rem;
+	font-size: 1.05rem;
+	color: var(--text-primary);
+}
+
+.grafico-wrapper {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr);
+	gap: 1rem;
+	align-items: stretch;
+}
+
+.eje-y {
+	display: flex;
+	flex-direction: column-reverse;
+	justify-content: space-between;
+	align-items: flex-end;
+	min-height: 360px;
+	padding: 0.5rem 0;
+	font-size: 0.8rem;
+	min-width: 2.5rem;
+}
+
+.grafico-scroll {
+	overflow-x: auto;
+	padding-bottom: 0.5rem;
+}
+
+.grafico {
+	position: relative;
+	min-height: 360px;
+	display: flex;
+	align-items: flex-end;
+	gap: 1rem;
+	padding: 0 0.25rem;
+	min-width: max(100%, calc(var(--max-victorias, 0) * 120px));
+}
+
+.lineas-fondo {
+	position: absolute;
+	inset: 0;
+	background-image: linear-gradient(to top, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+	background-size: 100% 20%;
+	pointer-events: none;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.columna {
+	position: relative;
+	z-index: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.75rem;
+	min-width: 96px;
+	flex: 0 0 96px;
+	height: 100%;
+}
+
+.barra-wrap {
+	width: 100%;
+	height: 280px;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+}
+
+.barra {
+	width: 100%;
+	max-width: 72px;
+	min-height: 4px;
+	border-radius: 18px 18px 8px 8px;
+	background: linear-gradient(180deg, var(--accent-lit), var(--green));
+	box-shadow: 0 0 24px rgba(0, 255, 136, 0.18);
+	position: relative;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.barra:hover {
+	transform: translateY(-3px);
+	box-shadow: 0 0 30px rgba(0, 255, 136, 0.26);
+}
+
+.valor {
+	position: absolute;
+	top: -1.4rem;
+	font-size: 0.9rem;
+	font-weight: 700;
+	color: var(--text-primary);
+	text-shadow: 0 0 12px rgba(0, 0, 0, 0.6);
+}
+
+.columna-meta {
+	width: 100%;
+	text-align: center;
+	min-height: 58px;
+}
+
+.columna-meta strong {
+	display: block;
+	font-size: 0.82rem;
+	line-height: 1.25;
+	word-break: break-word;
+}
+
+.columna-meta span {
+	display: block;
+	margin-top: 0.25rem;
+	font-size: 0.75rem;
+}
+
+@media (max-width: 760px) {
+	.estadisticas-page {
+		padding: 1rem;
+	}
+
+	.estadisticas-hero,
+	.estadisticas-panel {
+		padding: 1.1rem;
+	}
+
+	.grafico-wrapper {
+		grid-template-columns: 1fr;
+	}
+
+	.eje-y {
+		flex-direction: row;
+		min-height: auto;
+		min-width: 0;
+		justify-content: space-between;
+	}
+
+	.grafico {
+		min-width: max(100%, calc(var(--max-victorias, 0) * 110px));
+	}
+}

--- a/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.html
+++ b/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.html
@@ -1,0 +1,66 @@
+<section class="estadisticas-page">
+  <header class="estadisticas-hero">
+    <div class="estadisticas-copy">
+      <p class="eyebrow">Estadísticas del historial</p>
+      <h1>Victorias por juego</h1>
+      <p>
+        Consulta en qué minijuegos has ganado más partidas. El gráfico agrupa las victorias por nombre de juego usando el historial persistido.
+      </p>
+    </div>
+
+    <div class="estadisticas-actions">
+      <generic-button color="gray" link="/">Volver al inicio</generic-button>
+      <generic-button color="green" (click)="cargarEstadisticas()">Actualizar</generic-button>
+    </div>
+  </header>
+
+  <div class="estadisticas-state" *ngIf="cargando">
+    Cargando estadísticas...
+  </div>
+
+  <div class="estadisticas-state error" *ngIf="!cargando && errorMensaje">
+    {{ errorMensaje }}
+  </div>
+
+  <div class="estadisticas-state empty" *ngIf="!cargando && !errorMensaje && estadisticas.length === 0">
+    Aún no hay victorias registradas en tu historial.
+  </div>
+
+  <section class="estadisticas-panel" *ngIf="!cargando && !errorMensaje && estadisticas.length > 0">
+    <div class="estadisticas-panel-head">
+      <div>
+        <span class="panel-label">Jugador</span>
+        <strong>{{ usuarioNombre }}</strong>
+      </div>
+      <div>
+        <span class="panel-label">Victorias totales</span>
+        <strong>{{ totalVictorias }}</strong>
+      </div>
+    </div>
+
+    <div class="grafico-wrapper">
+      <div class="eje-y">
+        <span *ngFor="let tick of ticks">{{ tick }}</span>
+      </div>
+
+      <div class="grafico-scroll">
+        <div class="grafico" [style.--max-victorias]="maxVictorias">
+          <div class="lineas-fondo"></div>
+
+          <article class="columna" *ngFor="let juego of estadisticas; trackBy: trackJuego">
+            <div class="barra-wrap">
+              <div class="barra" [style.height.%]="juego.altura">
+                <span class="valor">{{ juego.victorias }}</span>
+              </div>
+            </div>
+
+            <div class="columna-meta">
+              <strong>{{ juego.juegoNombre }}</strong>
+              <span>{{ juego.partidas }} partidas</span>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+</section>

--- a/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.ts
+++ b/juegos1000tres-frontend/src/app/features/estadisticas/estadisticas.ts
@@ -1,0 +1,132 @@
+import { NgFor, NgIf } from '@angular/common';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, finalize, map, of, switchMap } from 'rxjs';
+import { GenericButton } from '../../shared/components/generic-button/generic-button';
+import { AuthService } from '../auth/services/auth.service';
+import { HistorialSala, HistorialService } from '../historial/historial.service';
+
+interface JuegoEstadistica {
+  juegoNombre: string;
+  victorias: number;
+  partidas: number;
+  altura: number;
+}
+
+@Component({
+  selector: 'app-estadisticas',
+  standalone: true,
+  imports: [NgIf, NgFor, GenericButton],
+  templateUrl: './estadisticas.html',
+  styleUrl: './estadisticas.css',
+})
+export class Estadisticas implements OnInit {
+  cargando = false;
+  errorMensaje = '';
+  usuarioNombre = '';
+  estadisticas: JuegoEstadistica[] = [];
+  maxVictorias = 0;
+  ticks: number[] = [0];
+  totalVictorias = 0;
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly historialService: HistorialService,
+    private readonly router: Router,
+    private readonly cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarEstadisticas();
+  }
+
+  cargarEstadisticas(): void {
+    this.cargando = true;
+    this.errorMensaje = '';
+    this.cdr.detectChanges();
+
+    this.authService.loadSession().pipe(
+      switchMap(usuario => {
+        if (!usuario || usuario.role !== 'USER') {
+          throw new Error('No se encontró un usuario registrado');
+        }
+
+        this.usuarioNombre = usuario.nombre;
+        return this.historialService.obtenerHistorial();
+      }),
+      map(salas => this.calcularEstadisticas(salas)),
+      catchError(() => {
+        this.estadisticas = [];
+        this.errorMensaje = 'No se pudieron cargar las estadísticas';
+        return of([] as JuegoEstadistica[]);
+      }),
+      finalize(() => {
+        this.cargando = false;
+        this.cdr.detectChanges();
+      })
+    ).subscribe({
+      next: estadisticas => {
+        this.estadisticas = estadisticas;
+        this.maxVictorias = estadisticas[0]?.victorias ?? 0;
+        this.ticks = this.crearTicks(this.maxVictorias);
+        this.totalVictorias = estadisticas.reduce((acumulado, item) => acumulado + item.victorias, 0);
+        this.cdr.detectChanges();
+      },
+    });
+  }
+
+  volverAlInicio(): void {
+    this.router.navigate(['/']);
+  }
+
+  trackJuego(_: number, juego: JuegoEstadistica): string {
+    return juego.juegoNombre;
+  }
+
+  private calcularEstadisticas(salas: HistorialSala[]): JuegoEstadistica[] {
+    const nombreUsuario = this.usuarioNombre.trim().toLowerCase();
+    const acumulado = new Map<string, { victorias: number; partidas: number }>();
+
+    for (const sala of salas) {
+      const juegos = 'juegosJugados' in sala ? sala.juegosJugados : [];
+
+      for (const juego of juegos) {
+        const ganadasPorUsuario = juego.ganadores.some(nombre => nombre.trim().toLowerCase() === nombreUsuario);
+        const actual = acumulado.get(juego.juegoNombre) ?? { victorias: 0, partidas: 0 };
+
+        actual.partidas += 1;
+        if (ganadasPorUsuario) {
+          actual.victorias += 1;
+        }
+
+        acumulado.set(juego.juegoNombre, actual);
+      }
+    }
+
+    const maximo = Math.max(...Array.from(acumulado.values()).map(valor => valor.victorias), 0);
+
+    return Array.from(acumulado.entries())
+      .map(([juegoNombre, valor]) => ({
+        juegoNombre,
+        victorias: valor.victorias,
+        partidas: valor.partidas,
+        altura: maximo > 0 ? (valor.victorias / maximo) * 100 : 0,
+      }))
+      .sort((izquierda, derecha) => derecha.victorias - izquierda.victorias || izquierda.juegoNombre.localeCompare(derecha.juegoNombre, 'es', { sensitivity: 'base' }));
+  }
+
+  private crearTicks(maximo: number): number[] {
+    if (maximo <= 0) {
+      return [0];
+    }
+
+    const pasos = Math.min(5, maximo);
+    const ticks = new Set<number>();
+
+    for (let indice = 0; indice <= pasos; indice += 1) {
+      ticks.add(Math.round((maximo * indice) / pasos));
+    }
+
+    return Array.from(ticks).sort((izquierda, derecha) => izquierda - derecha);
+  }
+}

--- a/juegos1000tres-frontend/src/app/features/home/home.html
+++ b/juegos1000tres-frontend/src/app/features/home/home.html
@@ -29,6 +29,8 @@
 				class="menu-bubble"
 				[disabled]="esInvitado"
 				[attr.aria-disabled]="esInvitado"
+				(click)="irAEstadisticas()"
+				*ngIf="!esInvitado"
 			>
 				Estadisticas
 			</button>

--- a/juegos1000tres-frontend/src/app/features/home/home.ts
+++ b/juegos1000tres-frontend/src/app/features/home/home.ts
@@ -58,6 +58,14 @@ export class Home implements OnInit {
     this.router.navigate(['/historial']);
   }
 
+  irAEstadisticas(): void {
+    if (this.esInvitado) {
+      return;
+    }
+
+    this.router.navigate(['/estadisticas']);
+  }
+
   cerrarAmigos(): void {
     this.mostrarAmigos = false;
   }


### PR DESCRIPTION
## Resumen
Añade la funcionalidad de estadísticas sobre qué juego el jugador ha ganado más. 

## Issue relacionado

Closes #49 

## Tipo de cambio
- [ ] Chore
- [ ] Bugfix
- [X] Nueva funcionalidad
- [ ] Refactor
- [ ] Documentacion
- [ ] Otro

## Decisiones técnicas (opcional)
- 



## Como probar
1. Acceder como usuario
2. Realizar partidas y ganar alguno de los juegos
3. Ir al menú de inicio y acceder a las estadísticas

## Checklist
- [X] He probado mis cambios localmente
- [X] No rompo funcionalidad existente
- [X] Incluyo pruebas o justifico por que no aplica

## Evidencia (opcional)
Capturas, logs o enlaces relacionados.
1. Logs de curl:
juegos1000tres-frontend-app  | 172.23.0.1 - - [27/May/2026:22:47:18 +0000] "GET /styles-UMD5YZXH.css HTTP/1.1" 304 0 "http://localhost:4200/estadisticas" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.121.0 Chrome/142.0.7444.265 Electron/39.8.8 Safari/537.36" "-"

2. Capturas de pantalla:
<img width="1766" height="949" alt="image" src="https://github.com/user-attachments/assets/46591ae6-1815-4b3f-b1f5-a420fcd00f14" />
