### PR TITLE
Arreglo en persistencia y puntuaciones de juegos

### DIFF
--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/AdivinaElPersonaje/AdivinaElPersonajeJuego.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/AdivinaElPersonaje/AdivinaElPersonajeJuego.java
@@ -343,6 +343,11 @@ public class AdivinaElPersonajeJuego extends Juego {
                 .toList());
 
         for (String ganadorId : this.ganadores) {
+            try {
+                this.salaService.establecerPuntuacion(this.salaId, ganadorId, 1);
+            } catch (RuntimeException ex) {
+                // no bloquear la finalización por fallos en puntuación
+            }
             this.salaService.incrementarVictoria(this.salaId, ganadorId);
         }
 

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/AdivinaElPersonaje/AdivinaElPersonajeJuego.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/AdivinaElPersonaje/AdivinaElPersonajeJuego.java
@@ -336,13 +336,35 @@ public class AdivinaElPersonajeJuego extends Juego {
         this.enCurso = false;
         int minimo = this.jugadores.values().stream().mapToInt(jugador -> jugador.preguntasAlAcertar).min().orElse(0);
 
-        this.ganadores.clear();
-        this.ganadores.addAll(this.jugadores.values().stream()
+        // Determinar el ganador verdadero: si hay empate elegimos uno de forma determinista
+        List<JugadorPartida> candidatos = new ArrayList<>(this.jugadores.values().stream()
                 .filter(jugador -> jugador.preguntasAlAcertar == minimo)
-                .map(jugador -> jugador.jugadorId)
-                .toList());
+            .toList());
 
-        for (String ganadorId : this.ganadores) {
+        if (candidatos.isEmpty()) {
+            this.ganadores.clear();
+        } else {
+            candidatos.sort(java.util.Comparator
+                    .comparingInt((JugadorPartida j) -> j.preguntasAlAcertar)
+                    .thenComparing(j -> j.nombreJugador, String.CASE_INSENSITIVE_ORDER)
+                    .thenComparing(j -> j.jugadorId));
+
+            JugadorPartida ganadorVerdadero = candidatos.get(0);
+            String ganadorId = ganadorVerdadero.jugadorId;
+
+            this.ganadores.clear();
+            this.ganadores.add(ganadorId);
+
+            for (String jugadorId : this.jugadores.keySet()) {
+                if (!jugadorId.equals(ganadorId)) {
+                    try {
+                        this.salaService.establecerPuntuacion(this.salaId, jugadorId, 0);
+                    } catch (RuntimeException ex) {
+                        // no bloquear la finalización por fallos en puntuación
+                    }
+                }
+            }
+
             try {
                 this.salaService.establecerPuntuacion(this.salaId, ganadorId, 1);
             } catch (RuntimeException ex) {

--- a/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/Dibujo/DibujoJuego.java
+++ b/juegos1000tres-backend/src/main/java/com/juegos1000tres/juegos1000tres_backend/juegos/Dibujo/DibujoJuego.java
@@ -196,12 +196,22 @@ public class DibujoJuego extends Juego {
             Jugador autor = this.jugadores.get(this.jugadorDibujaId);
             if (autor != null) {
                 autor.puntos += 15;
+                try {
+                    this.salaService.incrementarPuntuacion(this.salaId, autor.jugadorId, 15);
+                } catch (RuntimeException ex) {
+                    // no bloquear el flujo de juego por errores de persistencia
+                }
             }
 
             // Adivinador gana el bonus
             Jugador adivinador = this.jugadores.get(jugadorId);
             if (adivinador != null) {
                 adivinador.puntos += bonus;
+                try {
+                    this.salaService.incrementarPuntuacion(this.salaId, adivinador.jugadorId, bonus);
+                } catch (RuntimeException ex) {
+                    // no bloquear el flujo de juego por errores de persistencia
+                }
                 adivinador.mensajeEstado = "¡Correcto! Has adivinado la palabra";
                 adivinador.resultadoIntento = "ACIERTO";
             }


### PR DESCRIPTION
## Resumen
Es un arreglo a la hora de realizar las puntuaciones y mostrar el historial de los juegos "Dibujo" y "Adivina el personaje".

## Issue relacionado

Closes #51

## Tipo de cambio
- [ ] Chore
- [x] Bugfix
- [ ] Nueva funcionalidad
- [ ] Refactor
- [ ] Documentacion
- [ ] Otro

## Decisiones técnicas (opcional)


## Como probar
1. Es el mismo flujo de ejecución que al revisar el historial.

## Checklist
- [X] He probado mis cambios localmente
- [X] No rompo funcionalidad existente
- [X] Incluyo pruebas o justifico por que no aplica

## Evidencia (opcional)
Capturas, logs o enlaces relacionados.
1. Captura antes del arreglo: 
<img width="1336" height="655" alt="image" src="https://github.com/user-attachments/assets/7b1a03e9-4ced-4213-9b1d-31d8cc7c731e" />

2. Captura tras el arreglo: 
<img width="1290" height="658" alt="image" src="https://github.com/user-attachments/assets/9a28adab-00d8-4e13-af3d-9b7ab0b30607" />
